### PR TITLE
Pulling in v0.21 and passing $request to handle_request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+FCGI-Engine-*
 .DS_Store
 MYMETA.json
 MYMETA.yml

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension FCGI-Engine
 
+    - Use Config to find perl to run RT#69473
+
 0.19 Wed. Oct. 5, 2011
     - Fix tests to not fail when MooseX::NonMoose
       isn't installed.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension FCGI-Engine
 
+    - Fix RT#83636 by correctly importing the Config module.
+
 0.20 Mon. Feb. 25, 2013
     - Use Config to find perl to run RT#69473
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl extension FCGI-Engine
 
+0.21 Thu. Apr. 11, 2013
     - Fix RT#83636 by correctly importing the Config module.
 
 0.20 Mon. Feb. 25, 2013

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl extension FCGI-Engine
 
+0.20 Mon. Feb. 25, 2013
     - Use Config to find perl to run RT#69473
 
 0.19 Wed. Oct. 5, 2011

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,3 +1,4 @@
+^FCGI-Engine-
 ^_build
 ^Build$
 ^Build.PL$

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-FCGI-Engine version 0.20
+FCGI-Engine version 0.21
 ===========================
 
 See the individual module documentation for more information

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-FCGI-Engine version 0.19
+FCGI-Engine version 0.20
 ===========================
 
 See the individual module documentation for more information

--- a/lib/FCGI/Engine.pm
+++ b/lib/FCGI/Engine.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use CGI::Simple;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Core';

--- a/lib/FCGI/Engine.pm
+++ b/lib/FCGI/Engine.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use CGI::Simple;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Core';

--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -194,7 +194,8 @@ sub run {
         $proc_manager && $proc_manager->pre_dispatch;
 
         $self->handle_request(
-            $self->prepare_environment( $env )
+            $self->prepare_environment( $env ),
+            $request
         );
 
         $proc_manager && $proc_manager->post_dispatch;

--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -8,7 +8,7 @@ use FCGI::Engine::ProcManager;
 
 use constant DEBUG => 0;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 with 'MooseX::Getopt',

--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -8,7 +8,7 @@ use FCGI::Engine::ProcManager;
 
 use constant DEBUG => 0;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 with 'MooseX::Getopt',

--- a/lib/FCGI/Engine/Manager.pm
+++ b/lib/FCGI/Engine/Manager.pm
@@ -6,7 +6,7 @@ use FCGI::Engine::Manager::Server;
 
 use Config::Any;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 with 'MooseX::Getopt';

--- a/lib/FCGI/Engine/Manager.pm
+++ b/lib/FCGI/Engine/Manager.pm
@@ -6,7 +6,7 @@ use FCGI::Engine::Manager::Server;
 
 use Config::Any;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 with 'MooseX::Getopt';

--- a/lib/FCGI/Engine/Manager/Server.pm
+++ b/lib/FCGI/Engine/Manager/Server.pm
@@ -5,7 +5,7 @@ use MooseX::Daemonize::Pid::File;
 use FCGI::Engine::Types;
 use Config;
 
-our $VERSION   = '0.20'; 
+our $VERSION   = '0.21'; 
 our $AUTHORITY = 'cpan:STEVAN';
 
 has 'name' => (

--- a/lib/FCGI/Engine/Manager/Server.pm
+++ b/lib/FCGI/Engine/Manager/Server.pm
@@ -62,7 +62,9 @@ has 'pid_obj' => (
 
 sub construct_command_line {
     my $self = shift;
-    return ("perl",
+    my $perl = $Config{perlpath};
+    $perl .= $Config{_exe} if $^O ne 'VMS' and $perl !~ /$Config{_exe}$/i;
+    return ($perl,
          ($self->has_additional_args
              ? $self->additional_args
              : ()),

--- a/lib/FCGI/Engine/Manager/Server.pm
+++ b/lib/FCGI/Engine/Manager/Server.pm
@@ -3,6 +3,7 @@ use Moose;
 
 use MooseX::Daemonize::Pid::File;
 use FCGI::Engine::Types;
+use Config;
 
 our $VERSION   = '0.20'; 
 our $AUTHORITY = 'cpan:STEVAN';

--- a/lib/FCGI/Engine/Manager/Server.pm
+++ b/lib/FCGI/Engine/Manager/Server.pm
@@ -4,7 +4,7 @@ use Moose;
 use MooseX::Daemonize::Pid::File;
 use FCGI::Engine::Types;
 
-our $VERSION   = '0.19'; 
+our $VERSION   = '0.20'; 
 our $AUTHORITY = 'cpan:STEVAN';
 
 has 'name' => (

--- a/lib/FCGI/Engine/Manager/Server/FreeBSD6.pm
+++ b/lib/FCGI/Engine/Manager/Server/FreeBSD6.pm
@@ -1,7 +1,7 @@
 package FCGI::Engine::Manager::Server::FreeBSD6;
 use Moose;
 
-our $VERSION   = '0.19'; 
+our $VERSION   = '0.20'; 
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Manager::Server';

--- a/lib/FCGI/Engine/Manager/Server/FreeBSD6.pm
+++ b/lib/FCGI/Engine/Manager/Server/FreeBSD6.pm
@@ -1,7 +1,7 @@
 package FCGI::Engine::Manager::Server::FreeBSD6;
 use Moose;
 
-our $VERSION   = '0.20'; 
+our $VERSION   = '0.21'; 
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Manager::Server';

--- a/lib/FCGI/Engine/Manager/Server/Plackup.pm
+++ b/lib/FCGI/Engine/Manager/Server/Plackup.pm
@@ -1,7 +1,7 @@
 package FCGI::Engine::Manager::Server::Plackup;
 use Moose;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Manager::Server';

--- a/lib/FCGI/Engine/Manager/Server/Plackup.pm
+++ b/lib/FCGI/Engine/Manager/Server/Plackup.pm
@@ -1,7 +1,7 @@
 package FCGI::Engine::Manager::Server::Plackup;
 use Moose;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Manager::Server';

--- a/lib/FCGI/Engine/PSGI.pm
+++ b/lib/FCGI/Engine/PSGI.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use Plack::Util;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Core';

--- a/lib/FCGI/Engine/PSGI.pm
+++ b/lib/FCGI/Engine/PSGI.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use Plack::Util;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::Core';

--- a/lib/FCGI/Engine/ProcManager.pm
+++ b/lib/FCGI/Engine/ProcManager.pm
@@ -8,7 +8,7 @@ use POSIX qw(SA_RESTART SIGTERM SIGHUP);
 use FCGI::Engine::Types;
 use MooseX::Daemonize::Pid::File;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 has 'role' => (

--- a/lib/FCGI/Engine/ProcManager.pm
+++ b/lib/FCGI/Engine/ProcManager.pm
@@ -8,7 +8,7 @@ use POSIX qw(SA_RESTART SIGTERM SIGHUP);
 use FCGI::Engine::Types;
 use MooseX::Daemonize::Pid::File;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 has 'role' => (

--- a/lib/FCGI/Engine/Types.pm
+++ b/lib/FCGI/Engine/Types.pm
@@ -5,7 +5,7 @@ use Declare::Constraints::Simple '-All';
 use MooseX::Getopt::OptionTypeMap;
 use MooseX::Types::Path::Class;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 ## FCGI::Engine

--- a/lib/FCGI/Engine/Types.pm
+++ b/lib/FCGI/Engine/Types.pm
@@ -5,7 +5,7 @@ use Declare::Constraints::Simple '-All';
 use MooseX::Getopt::OptionTypeMap;
 use MooseX::Types::Path::Class;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 ## FCGI::Engine

--- a/lib/Plack/Handler/FCGI/Engine.pm
+++ b/lib/Plack/Handler/FCGI/Engine.pm
@@ -4,7 +4,7 @@ use MooseX::NonMoose;
 
 use Plack::Handler::FCGI::Engine::ProcManager;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI';

--- a/lib/Plack/Handler/FCGI/Engine.pm
+++ b/lib/Plack/Handler/FCGI/Engine.pm
@@ -4,7 +4,7 @@ use MooseX::NonMoose;
 
 use Plack::Handler::FCGI::Engine::ProcManager;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI';

--- a/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
@@ -1,7 +1,7 @@
 package Plack::Handler::FCGI::Engine::ProcManager;
 use Moose;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::ProcManager';

--- a/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
@@ -1,7 +1,7 @@
 package Plack::Handler::FCGI::Engine::ProcManager;
 use Moose;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'FCGI::Engine::ProcManager';

--- a/lib/Plack/Server/FCGI/Engine.pm
+++ b/lib/Plack/Server/FCGI/Engine.pm
@@ -1,7 +1,7 @@
 package Plack::Server::FCGI::Engine;
 use Moose;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI::Engine';

--- a/lib/Plack/Server/FCGI/Engine.pm
+++ b/lib/Plack/Server/FCGI/Engine.pm
@@ -1,7 +1,7 @@
 package Plack::Server::FCGI::Engine;
 use Moose;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI::Engine';

--- a/lib/Plack/Server/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Server/FCGI/Engine/ProcManager.pm
@@ -1,7 +1,7 @@
 package Plack::Server::FCGI::Engine::ProcManager;
 use Moose;
 
-our $VERSION   = '0.19';
+our $VERSION   = '0.20';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI::Engine::ProcManager';

--- a/lib/Plack/Server/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Server/FCGI/Engine/ProcManager.pm
@@ -1,7 +1,7 @@
 package Plack::Server::FCGI::Engine::ProcManager;
 use Moose;
 
-our $VERSION   = '0.20';
+our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
 extends 'Plack::Handler::FCGI::Engine::ProcManager';

--- a/t/023_manager_w_plackup.t
+++ b/t/023_manager_w_plackup.t
@@ -20,6 +20,16 @@ BEGIN {
         eval "use Plack 0.9910; use FCGI::Client 0.04; use MooseX::NonMoose 0.07; use IO::String;";
         plan skip_all => "Plack 0.9910, FCGI::Client and MooseX::NonMoose are required for this test" if $@;
     }
+    {
+        my $plackup_found = 0;
+        if (eval { require File::Which; 1 }) {
+            $plackup_found = 1 if (File::Which::which('plackup'));
+        }
+        else {
+            $plackup_found = 1 if length(`which plackup`);
+        }
+        plan skip_all => 'plackup must be in $PATH' unless $plackup_found;
+    }
     plan tests => 11;
     use_ok('FCGI::Engine::Manager');
 }

--- a/t/101_plack_server_fcgi_engine_client.t
+++ b/t/101_plack_server_fcgi_engine_client.t
@@ -9,8 +9,8 @@ use Test::More;
 BEGIN {
     {
         local $@;
-        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String;";
-        plan skip_all => "Plack 0.9910, FCGI::Client 0.06 and MooseX::NonMoose are required for this test" if $@;
+        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String; use Plack::App::FCGIDispatcher;";
+        plan skip_all => "Plack 0.9910, FCGI::Client 0.06, MooseX::NonMoose 0.07 and Plack::App::FCGIDispatcher are required for this test" if $@;
     }
 }
 


### PR DESCRIPTION
Initially a pull request based on v0.21. Added functionality for passing $request to the handle_request method. This is due to my work with an HTML templating engine that does internal forking for long-running page requests. In order to serve this over FCGI I need the original $request object to Detach/Attach as appropriate. This lets me do so in the handle_request method.
