### PR TITLE
Add psgix.harakiri support to FCGI::Engine::PSGI

### DIFF
--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -192,18 +192,24 @@ sub run {
     }
 
     while ($request->Accept() >= 0) {
-
-        $proc_manager && $proc_manager->pre_dispatch;
-
-        $self->handle_request(
-            $self->prepare_environment( $env ),
-            $request
+        $self->process_request(
+            $self->prepare_environment($env, $proc_manager),
+            $request,
+            $proc_manager
         );
-
-        $request->Finish();
-
-        $proc_manager && $proc_manager->post_dispatch;
     }
+}
+
+sub process_request {
+    my ($self, $env, $request, $proc_manager) = @_;
+
+    $proc_manager && $proc_manager->pre_dispatch;
+
+    $self->handle_request($env, $request);
+
+    $request->Finish();
+
+    $proc_manager && $proc_manager->post_dispatch;
 }
 
 1;

--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -200,6 +200,8 @@ sub run {
             $request
         );
 
+        $request->Finish();
+
         $proc_manager && $proc_manager->post_dispatch;
     }
 }

--- a/t/201_fcgi_engine_psgi.t
+++ b/t/201_fcgi_engine_psgi.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+
+use Test::More;
+
+BEGIN {
+    {
+        local $@;
+        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String; use Plack::App::FCGIDispatcher;";
+        plan skip_all => "Plack 0.9910, FCGI::Client 0.06, MooseX::NonMoose 0.07 and Plack::App::FCGIDispatcher are required for this test" if $@;
+    }
+}
+
+use FCGI::Engine::PSGI;
+use Test::TCP;
+use Plack::Test::Suite;
+use t::lib::FCGIUtils;
+
+my $http_port;
+my $fcgi_port;
+
+test_fcgi_standalone(
+   sub {
+       ($http_port, $fcgi_port) = @_;
+       Plack::Test::Suite->run_server_tests(\&run_server, $fcgi_port, $http_port);
+       done_testing();
+    }
+);
+
+sub run_server {
+    my($port, $app) = @_;
+
+    $| = 0; # Test::Builder autoflushes this. reset!
+
+    my $server = FCGI::Engine::PSGI->new(
+        listen      => "127.0.0.1:$port",
+        pidfile     => '/tmp/101_plack_server_fcgi_engine_client.pid',
+        app         => $app,
+    );
+    $server->run();
+}
+


### PR DESCRIPTION
FCGI::Engine::PSGI doesn't support the psgix.harakiri extension to allow app to request server to exit (usually to restart).

I added an empty cleanup_request method to handle the cleanup, but it might make sense to move the block inside while loop into method and do "after" or "around" modifier on that.

Also, FCGI::Engine should call FCGI::Request::Finish before post_dispatch. The FCGI::Request gets finished the next time around the loop, but that doesn't cleanup nicely if process exits.
