### PR TITLE
Support process_name in FCGI::Engine::ProcManager (RT #82318)

### DIFF
--- a/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
@@ -13,6 +13,13 @@ has 'pidfile' => (
     coerce   => 1,
 );
 
+has 'process_name' => (
+    init_arg => 'pm_title',
+    is       => 'ro',
+    isa      => 'Str',
+    default  => sub { 'perl-fcgi' },
+);
+
 # FCGI::ProcManager compat
 
 sub pm_manage        { (shift)->manage( @_ )        }


### PR DESCRIPTION
The fix for [RT #82318](https://rt.cpan.org/Ticket/Display.html?id=82318) was in bobtfish/fcgi-engine fork but didn't get merged upstream or released.
