### PR TITLE
Add Plack::Handler::FCGI::Engine::PSGI and tests

### DIFF
--- a/lib/Plack/Handler/FCGI/Engine/PSGI.pm
+++ b/lib/Plack/Handler/FCGI/Engine/PSGI.pm
@@ -1,0 +1,69 @@
+package Plack::Handler::FCGI::Engine::PSGI;
+
+use strict;
+
+use base 'Plack::Handler';
+
+our $VERSION   = '0.22';
+our $AUTHORITY = 'cpan:STEVAN';
+
+use FCGI::Engine::PSGI;
+
+sub new {
+    my($class, %args) = @_;
+    bless { %args }, $class;
+}
+
+sub run {
+    my($self, $app) = @_;
+    my $server = FCGI::Engine::PSGI->new(%$self, app => $app);
+    $server->run();
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Plack::Handler::FCGI::Engine::PSGI - A Plack::Handler backend for FCGI::Engine::PSGI
+
+=head1 SYNOPSIS
+
+  use Plack::Handler::FCGI::Engine::PSGI;
+
+  my $handler = Plack::Handler::FCGI::Engine::PSGI->new(
+      nproc  => $num_proc,
+      listen => $listen,
+      detach => 1,
+  );
+
+  $handler->run($app);
+
+=head1 DESCRIPTION
+
+This is a subclass of L<Plack::Handler> which will use the
+L<FCGI::Handler::PSGI> as handler.
+
+=head1 BUGS
+
+All complex software has bugs lurking in it, and this module is no
+exception. If you find a bug please either email me, or add the bug
+to cpan-RT.
+
+=head1 AUTHOR
+
+Stevan Little E<lt>stevan.little@iinteractive.comE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2009-2010 Infinity Interactive, Inc.
+
+L<http://www.iinteractive.com>
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/t/200_plack_server_fcgi_engine_psgi.t
+++ b/t/200_plack_server_fcgi_engine_psgi.t
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+
+use Test::More;
+
+BEGIN {
+    {
+        local $@;
+        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String; use Plack::App::FCGIDispatcher;";
+        plan skip_all => "Plack 0.9910, FCGI::Client 0.06, MooseX::NonMoose 0.07 and Plack::App::FCGIDispatcher are required for this test" if $@;
+    }
+}
+
+use Plack::Handler::FCGI::Engine::PSGI;
+use Test::TCP;
+use Plack::Test::Suite;
+use t::lib::FCGIUtils;
+
+my $http_port;
+my $fcgi_port;
+
+test_fcgi_standalone(
+   sub {
+       ($http_port, $fcgi_port) = @_;
+       Plack::Test::Suite->run_server_tests(\&run_server, $fcgi_port, $http_port);
+       done_testing();
+    }
+);
+
+sub run_server {
+    my($port, $app) = @_;
+
+    $| = 0; # Test::Builder autoflushes this. reset!
+
+    my $server = Plack::Handler::FCGI::Engine::PSGI->new(
+        listen      => "127.0.0.1:$port",
+        pidfile     => '/tmp/101_plack_server_fcgi_engine_client.pid',
+    );
+    $server->run($app);
+}
+

--- a/t/201_fcgi_engine_psgi.t
+++ b/t/201_fcgi_engine_psgi.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+
+use Test::More;
+
+BEGIN {
+    {
+        local $@;
+        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String; use Plack::App::FCGIDispatcher;";
+        plan skip_all => "Plack 0.9910, FCGI::Client 0.06, MooseX::NonMoose 0.07 and Plack::App::FCGIDispatcher are required for this test" if $@;
+    }
+}
+
+use FCGI::Engine::PSGI;
+use Test::TCP;
+use Plack::Test::Suite;
+use t::lib::FCGIUtils;
+
+my $http_port;
+my $fcgi_port;
+
+test_fcgi_standalone(
+   sub {
+       ($http_port, $fcgi_port) = @_;
+       Plack::Test::Suite->run_server_tests(\&run_server, $fcgi_port, $http_port);
+       done_testing();
+    }
+);
+
+sub run_server {
+    my($port, $app) = @_;
+
+    $| = 0; # Test::Builder autoflushes this. reset!
+
+    my $server = FCGI::Engine::PSGI->new(
+        listen      => "127.0.0.1:$port",
+        pidfile     => '/tmp/101_plack_server_fcgi_engine_client.pid',
+        app         => $app,
+    );
+    $server->run();
+}
+


### PR DESCRIPTION
Plack::Handler::FCGI::Engine uses Plack::Handler::FCGI with FCGI::Engine::ProcManager. FCGI::Engine::PSGI has a different interface than Plack::Handler.

```
FCGI::Engine::PSGI->new(app => $app)->run();

Plack::Handler::FCGI::Engine::PSGI->new()->run($app);
```

The latter can be used with "plackup" -s option. (-s FCGI::Engine::PSGI).

Also, adds Plack::Test::Suite tests for Plack::Handler::FCGI::Engine::PSGI and FCGI::Engine::PSGI.
