### PR TITLE
Call $request->Finish() 

### DIFF
--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -200,6 +200,8 @@ sub run {
             $request
         );
 
+        $request->Finish();
+
         $proc_manager && $proc_manager->post_dispatch;
     }
 }

--- a/t/201_fcgi_engine_psgi.t
+++ b/t/201_fcgi_engine_psgi.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+
+use Test::More;
+
+BEGIN {
+    {
+        local $@;
+        eval "use Plack 0.9910; use FCGI::Client 0.06; use MooseX::NonMoose 0.07; use IO::String; use Plack::App::FCGIDispatcher;";
+        plan skip_all => "Plack 0.9910, FCGI::Client 0.06, MooseX::NonMoose 0.07 and Plack::App::FCGIDispatcher are required for this test" if $@;
+    }
+}
+
+use FCGI::Engine::PSGI;
+use Test::TCP;
+use Plack::Test::Suite;
+use t::lib::FCGIUtils;
+
+my $http_port;
+my $fcgi_port;
+
+test_fcgi_standalone(
+   sub {
+       ($http_port, $fcgi_port) = @_;
+       Plack::Test::Suite->run_server_tests(\&run_server, $fcgi_port, $http_port);
+       done_testing();
+    }
+);
+
+sub run_server {
+    my($port, $app) = @_;
+
+    $| = 0; # Test::Builder autoflushes this. reset!
+
+    my $server = FCGI::Engine::PSGI->new(
+        listen      => "127.0.0.1:$port",
+        pidfile     => '/tmp/101_plack_server_fcgi_engine_client.pid',
+        app         => $app,
+    );
+    $server->run();
+}
+


### PR DESCRIPTION
$request->Accept() will finish the previous request if it hasn't been finished. It is important to call Finish() the request before calling post_dispatch() since post_dispatch can exit which interfere with sending back response.
