### PR TITLE
Implement pm_exit

### DIFF
--- a/lib/FCGI/Engine/ProcManager.pm
+++ b/lib/FCGI/Engine/ProcManager.pm
@@ -334,8 +334,10 @@ sub die : method {
     $SIG{HUP}  = 'DEFAULT';
     $SIG{TERM} = 'DEFAULT';
 
-    $self->pidfile->remove
-        || $self->notify("Could not remove PID file: $!");
+    if ($self->pidfile->does_file_exist) {
+        $self->pidfile->remove
+            || $self->notify("Could not remove PID file: $!");
+    }
 
     # prepare to die no matter what.
     if (defined $self->die_timeout) {

--- a/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
@@ -18,6 +18,7 @@ has 'pidfile' => (
 sub pm_manage        { (shift)->manage( @_ )        }
 sub pm_pre_dispatch  { (shift)->pre_dispatch( @_ )  }
 sub pm_post_dispatch { (shift)->post_dispatch( @_ ) }
+sub pm_exit          { (shift)->die( @_ ) }
 
 sub notify {
     my ($self, $msg) = @_;


### PR DESCRIPTION
Further compatibility with `FCGI::ProcManager`.  Implements `pm_exit` for use with `psgix.harakiri.commit`.

Also checks for pid file before removing.